### PR TITLE
Add Support for DumpContainer Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,21 @@ For more compact level names, use a format such as `{Level:u3}` or `{Level:w3}` 
 
 ---
 
+## Log to DumpContainer
+
+---
+
+Optional log to a specified `DumpContainer`.
+
+```csharp
+DumpContainer logContainer = new DumpContainer().Dump("Log Messages");
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.LINQPad(dumpContainer: logContainer)
+    .CreateLogger();
+```
+
+Writes the log messages to the specified `DumpContainer`, when not wanted directly appended to the result panel.
+
+---
+
 _Copyright &copy; 2016 Serilog Contributors - Provided under the [Apache License, Version 2.0](http://apache.org/licenses/LICENSE-2.0.html)._

--- a/src/Serilog.Sinks.LINQPad/LINQPadLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.LINQPad/LINQPadLoggerConfigurationExtensions.cs
@@ -45,6 +45,7 @@ namespace Serilog
         /// to be changed at runtime.</param>
         /// <param name="theme">The theme to apply to the styled output. If not specified,
         /// uses <see cref="LINQPadTheme.LINQPadLiterate"/> or if dark-mode is enabled <see cref="LINQPadTheme.LINQPadDark"/>.</param>
+        /// <param name="dumpContainer">optional write to a specified <see cref="DumpContainer"/> and not direct to the result panel</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration LINQPad(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -52,7 +53,9 @@ namespace Serilog
             string outputTemplate = DefaultConsoleOutputTemplate,
             IFormatProvider formatProvider = null,
             LoggingLevelSwitch levelSwitch = null,
-            ConsoleTheme theme = null)
+            ConsoleTheme theme = null,
+            DumpContainer dumpContainer = null
+            )
         {
             if (sinkConfiguration == null) {
                 throw new ArgumentNullException(nameof(sinkConfiguration));
@@ -65,7 +68,7 @@ namespace Serilog
             var appliedTheme = theme ?? (Util.IsDarkThemeEnabled ? DefaultThemes.LINQPadDark : DefaultThemes.LINQPadLiterate);
 
             var formatter = new OutputTemplateRenderer(appliedTheme, outputTemplate, formatProvider);
-            return sinkConfiguration.Sink(new LINQPadSink(appliedTheme, formatter), restrictedToMinimumLevel, levelSwitch);
+            return sinkConfiguration.Sink(new LINQPadSink(appliedTheme, formatter, dumpContainer), restrictedToMinimumLevel, levelSwitch);
         }
 
         /// <summary>
@@ -78,12 +81,14 @@ namespace Serilog
         /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
         /// <param name="levelSwitch">A switch allowing the pass-through minimum level
         /// to be changed at runtime.</param>
+        /// <param name="dumpContainer">optional write to a specified <see cref="DumpContainer"/> and not direct to the result panel</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration LINQPad(
             this LoggerSinkConfiguration sinkConfiguration,
             ITextFormatter formatter,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
+            LoggingLevelSwitch levelSwitch = null,
+            DumpContainer dumpContainer = null)
         {
             if (sinkConfiguration == null) {
                 throw new ArgumentNullException(nameof(sinkConfiguration));
@@ -93,7 +98,7 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(formatter));
             }
 
-            return sinkConfiguration.Sink(new LINQPadSink(DefaultThemes.None, formatter), restrictedToMinimumLevel, levelSwitch);
+            return sinkConfiguration.Sink(new LINQPadSink(DefaultThemes.None, formatter, dumpContainer), restrictedToMinimumLevel, levelSwitch);
         }
     }
 }

--- a/src/Serilog.Sinks.LINQPad/Serilog.Sinks.LINQPad.csproj
+++ b/src/Serilog.Sinks.LINQPad/Serilog.Sinks.LINQPad.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LINQPad" Version="5.40.0" Condition="'$(TargetFramework)' == 'net48'" />
-    <PackageReference Include="LINQPad.Runtime" Version="7.2.7" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="LINQPad" Version="5.46.0" Condition="'$(TargetFramework)' == 'net48'" />
+    <PackageReference Include="LINQPad.Runtime" Version="7.6.6" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
 

--- a/tests/Serilog.Sinks.LINQPad.Tests/LINQPadSinkTests.cs
+++ b/tests/Serilog.Sinks.LINQPad.Tests/LINQPadSinkTests.cs
@@ -1,5 +1,7 @@
 using System;
 
+using LINQPad;
+
 using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.LINQPad.Output;
@@ -24,5 +26,25 @@ namespace Serilog.Sinks.LINQPad
         }
 
         private const string DefaultConsoleOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
+
+
+        [Fact]
+        public void TestDumpContainer()
+        {
+            var theme = DefaultThemes.LINQPadLiterate;
+            var formatter = new OutputTemplateRenderer(theme, DefaultConsoleOutputTemplate, null);
+            var dcLogger = new DumpContainer();
+            var sink = new LINQPadSink(theme, formatter, dcLogger);
+
+            var contentChanged = false;
+            dcLogger.ContentChanged += (s, e) => contentChanged = true;
+
+            var msg = new MessageTemplate("Hello World", new MessageTemplateToken[0]);
+            var evt = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Debug, null, msg, new LogEventProperty[0]);
+
+            sink.Emit(evt);
+
+            Assert.True(contentChanged);
+        }
     }
 }

--- a/tests/Serilog.Sinks.LINQPad.Tests/Serilog.Sinks.LINQPad.Tests.csproj
+++ b/tests/Serilog.Sinks.LINQPad.Tests/Serilog.Sinks.LINQPad.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Add Support for `DumpContainer` as logging target,
instead of appending direct to the result panel.

* added example to README.md
* updated NuGet Packages
* very simple test that the DumpContainer.Content was changed after a log message

Testet with LINQPad 5 and 7